### PR TITLE
Fix a memory leak in map

### DIFF
--- a/include/map.h
+++ b/include/map.h
@@ -48,61 +48,58 @@ class CubicCoordinate;
 
 class Map : public sf::Drawable {
  public:
- /*
-  * Create a map in the shape of a hexagon with the specified radius.
-  */
+  /*
+   * Create a map in the shape of a hexagon with the specified radius.
+   */
     explicit Map(size_t radius,
                  std::function<Tile*(Map*,AxialCoordinate&&)> initilizer,
 		 Game* gameObject);
-    /*
-    * Get a tile in the map from a coordinate.
-    * If there is no tile at the specified coordinate, this returns nullptr.
-    * If the specified coordinate is invalid, this returns nullptr.
-    * Otherwise, a pointer to the tile is returned.
-    */
-    Tile* GetTile(const AxialCoordinate* const coord) const;
-    Tile* GetTile(const AxialCoordinate& coord) const;
-    Tile* GetTile(const AxialCoordinate&& coord) const;
-    Tile* GetTile(const AxialCoordinate* const coord);
-    Tile* GetTile(const AxialCoordinate& coord);
-    Tile* GetTile(const AxialCoordinate&& coord);
-    /*
-    * Get an unordered list of the tiles within a radius of a given tile.
-    */
-    std::vector<Tile*> GetTilesInRange(const Tile* source, size_t radius) const;
-    /*
-    * Returns true if the specified coordinate is within the bounds of the map
-    */
-    bool IsCoordinateInBounds(const AxialCoordinate* const coord) const;
-    bool IsCoordinateInBounds(const AxialCoordinate& coord) const;
-    bool IsCoordinateInBounds(const AxialCoordinate&& coord) const;
+  /*
+   * Get a tile in the map from a coordinate.
+   * If there is no tile at the specified coordinate, this returns nullptr.
+   * If the specified coordinate is invalid, this returns nullptr.
+   * Otherwise, a pointer to the tile is returned.
+   */
+   Tile* GetTile(const AxialCoordinate* const coord) const;
+   Tile* GetTile(const AxialCoordinate& coord) const;
+   Tile* GetTile(const AxialCoordinate&& coord) const;
+   Tile* GetTile(const AxialCoordinate* const coord);
+   Tile* GetTile(const AxialCoordinate& coord);
+   Tile* GetTile(const AxialCoordinate&& coord);
+  /*
+   * Get an unordered list of the tiles within a radius of a given tile.
+   */
+   std::vector<Tile*> GetTilesInRange(const Tile* source, size_t radius) const;
+  /*
+   * Returns true if the specified coordinate is within the bounds of the map
+   */
+   bool IsCoordinateInBounds(const AxialCoordinate* const coord) const;
+   bool IsCoordinateInBounds(const AxialCoordinate& coord) const;
+   bool IsCoordinateInBounds(const AxialCoordinate&& coord) const;
 
-    /*
-     * Get the game object
-     */
-    const Game* GetGameObject() const { return game; }
+  /*
+   * Get the game object
+   */
+  const Game* GetGameObject() const { return game; }
 
-    /*
-     * Draw the map to the specified render target by drawing all of it's tiles
-     */
-    virtual void draw( sf::RenderTarget& target, sf::RenderStates states)
-                       const;
+  /*
+   * Draw the map to the specified render target by drawing all of it's tiles
+   */
+  virtual void draw( sf::RenderTarget& target, sf::RenderStates states)
+                      const;
 
-    /*
-     * Invoked when the display changes size
-     */
-    void OnDisplayResize();
+  /*
+   * Invoked when the display changes size
+   */
+  void OnDisplayResize();
  private:
-    // Represent the map using a 2D matrix
-    // This approach is simple to implement but will have space overhead
-    // especially in the case of maps with distant 'islands' and empty space
-    // between them. In this scenerio it may be better to use a hash table.
-    // This vector is indexed by AxialCoordinates
-    std::vector<std::vector<Tile*>> tiles;
+  // Represent the map using a 2D matrix
+  // This approach is simple to implement but will have space overhead
+  // especially in the case of maps with distant 'islands' and empty space
+  // between them. In this scenerio it may be better to use a hash table.
+  // This vector is indexed by AxialCoordinates
+  std::vector<std::vector<Tile*>> tiles;
 
-    // The game which this map belongs to
-    Game* game;
-
- public:
-    const std::vector<std::vector<Tile *>> &getTiles() const;
+  // The game which this map belongs to
+  Game* game;
 };

--- a/include/map.h
+++ b/include/map.h
@@ -51,9 +51,11 @@ class Map : public sf::Drawable {
   /*
    * Create a map in the shape of a hexagon with the specified radius.
    */
-    explicit Map(size_t radius,
-                 std::function<Tile*(Map*,AxialCoordinate&&)> initilizer,
-		 Game* gameObject);
+  explicit Map(size_t radius,
+               std::function<Tile*(Map*,AxialCoordinate&&)> initilizer,
+               Game* gameObject);
+  ~Map();
+
   /*
    * Get a tile in the map from a coordinate.
    * If there is no tile at the specified coordinate, this returns nullptr.

--- a/src/map.cc
+++ b/src/map.cc
@@ -54,6 +54,19 @@ Map::Map(size_t radius,
 }
 
 /*
+ * Map::~Map
+ */
+
+Map::~Map() {
+  for(auto row : tiles) {
+    for(Tile* tile : row) {
+      if(tile)
+        delete tile;
+    }
+  }
+}
+
+/*
  * Map::GetTile
  */
 

--- a/src/map.cc
+++ b/src/map.cc
@@ -128,10 +128,6 @@ bool Map::IsCoordinateInBounds(const AxialCoordinate&& coord) const {
   return IsCoordinateInBounds(bind);
 }
 
-const std::vector<std::vector<Tile *>> &Map::getTiles() const {
-    return tiles;
-}
-
 /*
  * Map::draw
  */


### PR DESCRIPTION
The map class, which holds dynamically allocated tiles, never freed these tiles. This caused a significant memory leak as tiles contain textures which take up considerable memory.

This has been resolved by adding a destructor to Map which deletes all of its tiles.